### PR TITLE
Change all timestamps to utc_datetime_usec

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ import Config
 
 config :dash_float,
   ecto_repos: [DashFloat.Repo],
-  generators: [timestamp_type: :utc_datetime]
+  generators: [timestamp_type: :utc_datetime_usec]
 
 # Configures the endpoint
 config :dash_float, DashFloatWeb.Endpoint,


### PR DESCRIPTION
This sets the generators to switch from utc_datetime to utc_datetime_usec when creating new schemas or migration.

This is to make sure that time is always accurate and is set to UTC.

For more reading:
https://stackoverflow.com/questions/22922155/postgresql-jdbc-and-timestamp-vs-timestamptz